### PR TITLE
Fix MatchError when :erlsom.scan return {:ok, {}, '\n'}

### DIFF
--- a/lib/castile.ex
+++ b/lib/castile.ex
@@ -370,14 +370,14 @@ defmodule Castile do
       {:ok, %{status_code: 200, body: body}} ->
         # TODO: check content type for multipart
         # TODO: handle response headers
-        {:ok, resp, []} = :erlsom.scan(body, model.model, output_encoding: :utf8)
+        {:ok, resp, _} = :erlsom.scan(body, model.model, output_encoding: :utf8)
 
         output = resolve_element(op.output, types)
         soap_envelope(body: soap_body(choice: [{^output, _, body}])) = resp
         # parse body further into a map
         {:ok, transform(body, types)}
       {:ok, %{status_code: 500, body: body}} ->
-        {:ok, resp, []} = :erlsom.scan(body, model.model, output_encoding: :utf8)
+        {:ok, resp, _} = :erlsom.scan(body, model.model, output_encoding: :utf8)
         soap_envelope(body: soap_body(choice: [soap_fault() = fault])) = resp
         {:error, transform(fault, types)}
     end


### PR DESCRIPTION
Thanks for this awesome library. I am trying to use it in my project, and meet this error:

```
iex(1)> CTUGSX.SOAP.test_authenticate
** (MatchError) no match of right hand side value: {:ok, {:"soap:Envelope", [], :undefined, {:"soap:Body", [], [{:"P:authenticateResponseWrapper", [], {:"P:authenticateResponseType", [], "Sdt7tXp2XytTEVwHBeDx6lHTXI3w9s+M", "teHHI9DcQcLsTBtI7+jdLqmOFqFrRaMZ"}}]}, :undefined}, '\n'}
    (castile) lib/castile.ex:373: Castile.call/5
```

and then found that `:erlsom.scan/3` return `{ok, Structure, TrailingCharacters}` and I think we should just use `_` to ignore the TrailingCharacters. And then I solve my problem.